### PR TITLE
Update code to fix plugin/ui shared state

### DIFF
--- a/src/distrho_plugin_server.h
+++ b/src/distrho_plugin_server.h
@@ -63,6 +63,7 @@ private:
     Ref<Mutex> audio_mutex;
 
     Ref<Thread> rpc_thread;
+    Ref<Thread> client_thread;
 
     Vector<DistrhoCircularBuffer *> input_channels;
     Vector<DistrhoCircularBuffer *> output_channels;
@@ -72,6 +73,9 @@ private:
 
     std::queue<MidiEvent> midi_output_queue;
     std::mutex midi_output_mutex;
+
+    std::queue<std::pair<String, String>> state_queue;
+    std::mutex state_mutex;
 
     Vector<float> parameters;
     Dictionary state_values;
@@ -90,6 +94,7 @@ public:
     void initialize();
     void audio_thread_func();
     void rpc_thread_func();
+    void client_thread_func();
 
     void process();
     void emit_midi_event(MidiEvent &p_midi_event);

--- a/src/plugin/godot_distrho_plugin.cpp
+++ b/src/plugin/godot_distrho_plugin.cpp
@@ -113,7 +113,8 @@ void GodotDistrhoPlugin::setState(const char* key, const char* value) {
 }
 
 void GodotDistrhoPlugin::initState(uint32_t p_index, State& p_state) {
-    p_state = *state->state_values[p_index];
+    p_state.key = state->state_values[p_index]->key;
+    p_state.defaultValue = state->state_values[p_index]->label;
 }
 
 void GodotDistrhoPlugin::run(const float **inputs, float **outputs, uint32_t numSamples, const MidiEvent *midiEvents,

--- a/src/plugin/godot_distrho_plugin_client.cpp
+++ b/src/plugin/godot_distrho_plugin_client.cpp
@@ -281,10 +281,13 @@ void GodotDistrhoPluginClient::set_parameter_value(int p_index, float p_value) {
 
 bool GodotDistrhoPluginClient::get_initial_state_value(int p_index, State &p_state) {
     bool result;
-    capnp::FlatArrayMessageReader reader = rpc_call<GetInitialStateValueRequest, GetInitialStateValueResponse>(result);
+    capnp::FlatArrayMessageReader reader = rpc_call<GetInitialStateValueRequest, GetInitialStateValueResponse>(result, [p_index](auto &req) {
+            req.setIndex(p_index);
+        });
+
     GetInitialStateValueResponse::Reader response = reader.getRoot<GetInitialStateValueResponse>();
     p_state.key = response.getKey().cStr();
-    p_state.label = response.getValue().cStr();
+    p_state.defaultValue = response.getValue().cStr();
 
     return result;
 }

--- a/src/plugin/godot_distrho_plugin_server.cpp
+++ b/src/plugin/godot_distrho_plugin_server.cpp
@@ -48,7 +48,7 @@ void GodotDistrhoPluginServer::rpc_thread_func() {
             scoped_lock<interprocess_mutex> shared_memory_lock(godot_rpc_memory->buffer->mutex);
 
             if (godot_rpc_memory->buffer->ready) {
-                ptime timeout = microsec_clock::universal_time() + milliseconds(first_wait ? 1000 : 100);
+                ptime timeout = microsec_clock::universal_time() + milliseconds(first_wait ? 1000 : 10);
                 bool result = godot_rpc_memory->buffer->input_condition.timed_wait(shared_memory_lock, timeout);
                 first_wait = false;
 


### PR DESCRIPTION
The client was blocking the audio thread and causing the audio to skip when rendering.  Move the client to it's own thread and also set the correct default values.